### PR TITLE
Allow Renovate pre-releases for Ombi

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,9 @@
       customType: "jsonata",
       fileFormat: "yaml",
       managerFilePatterns: ["**/appconfig.yaml"],
-      matchStrings: ['[{ "depName": origin, "currentValue": version }]'],
+      matchStrings: ['[{ "depName": origin, "currentValue": version, "datasource": datasource }]'],
+      // Apps may override the datasource in their appconfig.yaml; otherwise
+      // fall back to github-tags.
       datasourceTemplate: "github-tags",
       versioningTemplate: "loose",
     },
@@ -17,6 +19,12 @@
       matchDatasources: ["github-tags"],
       matchUpdateTypes: ["minor", "patch"],
       automerge: true,
+    },
+    {
+      // Ombi only publishes GitHub pre-releases (its develop channel), so
+      // allow Renovate to propose unstable versions for it.
+      matchDepNames: ["Ombi-app/Ombi"],
+      ignoreUnstable: false,
     },
     {
       matchManagers: ["dockerfile"],

--- a/Ombi/appconfig.yaml
+++ b/Ombi/appconfig.yaml
@@ -1,3 +1,6 @@
 name: Ombi
 origin: Ombi-app/Ombi
 version: v4.59.5
+# Ombi ships its develop builds as GitHub pre-releases, so track releases
+# (prerelease-aware) instead of raw tags. See ignoreUnstable rule in renovate.json5.
+datasource: github-releases


### PR DESCRIPTION
## What

Make Renovate track Ombi's pre-release (develop) builds.

## Why

Ombi ships its develop builds **only as GitHub pre-releases** (`v4.60.x` are all `prerelease: true`), while its stable line sits at `v4.59.x`. The current `github-tags` datasource lists raw git tags and can't tell a pre-release from a stable release, so there's no way to opt into the pre-release channel with it.

## How

- `Ombi/appconfig.yaml`: add `datasource: github-releases` (prerelease-aware).
- `.github/renovate.json5`:
  - the custom JSONata manager now extracts an optional per-app `datasource`, falling back to `github-tags` for every other app (no change for Prowlarr/Radarr/Sonarr).
  - add a packageRule scoping `ignoreUnstable: false` to `Ombi-app/Ombi` so Renovate proposes pre-release versions for Ombi only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)